### PR TITLE
feat(compat): Anthropic Claude-compatible endpoints (/anthropic/v1)

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -8,3 +8,6 @@ jobs:
   build_tests:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
+    with:
+      install_extras: "dev"
+      test_path: "tests"

--- a/ovos_persona_server/__init__.py
+++ b/ovos_persona_server/__init__.py
@@ -61,6 +61,7 @@ def create_persona_app(persona_path: str, a2a_base_url: Optional[str] = None) ->
     # imported here only after the Persona object is loaded
     from ovos_persona_server.chat import chat_router
     from ovos_persona_server.ollama import ollama_router
+    from ovos_persona_server.anthropic import anthropic_router
     from ovos_persona_server.deprecated_routers import (
         add_deprecation_middleware,
         register_deprecated_routes,
@@ -69,6 +70,7 @@ def create_persona_app(persona_path: str, a2a_base_url: Optional[str] = None) ->
     # Canonical prefixed routers
     app.include_router(chat_router)         # /openai/v1/...
     app.include_router(ollama_router)       # /ollama/api/...
+    app.include_router(anthropic_router)    # /anthropic/v1/...
 
     # Legacy deprecated paths — same handlers, with Deprecation + Link headers
     register_deprecated_routes(app)         # /v1/... and /api/... (deprecated)

--- a/ovos_persona_server/anthropic.py
+++ b/ovos_persona_server/anthropic.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0
+"""Anthropic Claude-compatible API endpoints."""
+import json
+import random
+import string
+import time
+from typing import AsyncGenerator, Dict, List, Optional, Union
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse, StreamingResponse
+from ovos_persona import Persona
+
+from ovos_persona_server.persona import get_default_persona
+from ovos_persona_server.schemas.anthropic import (
+    AnthropicContentBlock,
+    AnthropicRequest,
+    AnthropicResponse,
+    AnthropicUsage,
+)
+
+anthropic_router = APIRouter(prefix="/anthropic/v1", tags=["anthropic"])
+
+
+def _normalise_messages(request: AnthropicRequest) -> List[Dict[str, str]]:
+    """Normalise Anthropic messages to persona-compatible format.
+
+    Prepends system message if provided. Flattens content block lists to strings.
+
+    Args:
+        request: Anthropic API request.
+
+    Returns:
+        List of message dicts with 'role' and 'content' string keys.
+    """
+    messages: List[Dict[str, str]] = []
+    if request.system:
+        messages.append({"role": "system", "content": request.system})
+    for msg in request.messages:
+        if isinstance(msg.content, str):
+            content = msg.content
+        else:
+            content = " ".join(block.text for block in msg.content)
+        messages.append({"role": msg.role, "content": content})
+    return messages
+
+
+@anthropic_router.post("/messages", response_model=None)
+async def create_message(
+        request: AnthropicRequest,
+        persona: Persona = Depends(get_default_persona),
+        x_api_key: Optional[str] = Header(default=None, alias="x-api-key"),
+) -> Union[JSONResponse, StreamingResponse]:
+    """Create a message (Anthropic Claude-compatible).
+
+    Args:
+        request: Anthropic messages request body.
+        persona: Injected persona instance.
+        x_api_key: Anthropic API key header (accepted, ignored).
+
+    Returns:
+        JSON response or SSE stream in Anthropic format.
+    """
+    messages = _normalise_messages(request)
+    msg_id = "msg_" + "".join(random.choices(string.ascii_letters + string.digits, k=24))
+
+    if not request.stream:
+        try:
+            content = persona.chat(messages)
+            return JSONResponse(AnthropicResponse(
+                id=msg_id,
+                content=[AnthropicContentBlock(type="text", text=content)],
+                model=request.model,
+                usage=AnthropicUsage(
+                    input_tokens=sum(len(m["content"].split()) for m in messages),
+                    output_tokens=len(content.split()),
+                ),
+            ).model_dump())
+        except Exception as exc:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                                detail=f"Persona chat failed: {exc}") from exc
+
+    async def _stream() -> AsyncGenerator[str, None]:
+        """Yield SSE events in Anthropic streaming format."""
+        yield (
+            f"event: message_start\ndata: {{\"type\":\"message_start\","
+            f"\"message\":{{\"id\":\"{msg_id}\",\"type\":\"message\","
+            f"\"role\":\"assistant\",\"content\":[],"
+            f"\"model\":\"{request.model}\",\"stop_reason\":null,"
+            f"\"usage\":{{\"input_tokens\":0,\"output_tokens\":0}}}}}}\n\n"
+        )
+        yield (
+            "event: content_block_start\ndata: {\"type\":\"content_block_start\","
+            "\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n"
+        )
+
+        try:
+            for chunk in persona.stream(messages):
+                if chunk:
+                    delta = json.dumps({
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": chunk},
+                    })
+                    yield f"event: content_block_delta\ndata: {delta}\n\n"
+        except Exception as exc:
+            yield f"event: error\ndata: {{\"type\":\"error\",\"error\":{{\"message\":\"{exc}\"}}}}\n\n"
+            return
+
+        yield "event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n"
+        yield (
+            "event: message_delta\ndata: {\"type\":\"message_delta\","
+            "\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":0}}\n\n"
+        )
+        yield "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")

--- a/ovos_persona_server/schemas/anthropic.py
+++ b/ovos_persona_server/schemas/anthropic.py
@@ -1,0 +1,49 @@
+# Licensed under the Apache License, Version 2.0
+"""Pydantic schemas for Anthropic Claude API compatibility."""
+from typing import List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+class AnthropicContentBlock(BaseModel):
+    """A single content block in an Anthropic message."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class AnthropicMessage(BaseModel):
+    """A message in an Anthropic conversation."""
+
+    role: Literal["user", "assistant", "system"]
+    content: Union[str, List[AnthropicContentBlock]] = Field(..., description="Message content")
+
+
+class AnthropicRequest(BaseModel):
+    """Request body for POST /v1/messages."""
+
+    model: str = Field(..., min_length=1)
+    messages: List[AnthropicMessage] = Field(..., min_length=1)
+    system: Optional[str] = Field(default=None, min_length=1)
+    max_tokens: int = Field(default=1024, gt=0)
+    stream: bool = False
+
+
+class AnthropicUsage(BaseModel):
+    """Token usage in Anthropic response."""
+
+    input_tokens: int = Field(default=0, ge=0)
+    output_tokens: int = Field(default=0, ge=0)
+
+
+class AnthropicResponse(BaseModel):
+    """Response for POST /v1/messages."""
+
+    id: str = Field(..., min_length=1)
+    type: Literal["message"] = "message"
+    role: Literal["assistant"] = "assistant"
+    content: List[AnthropicContentBlock]
+    model: str = Field(..., min_length=1)
+    stop_reason: str = "end_turn"
+    stop_sequence: Optional[str] = None
+    usage: AnthropicUsage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 a2a = ["a2a-sdk>=0.3.0", "httpx>=0.27"]
-dev = ["pytest>=7.0", "pytest-asyncio", "pytest-cov", "httpx"]
+dev = ["pytest>=7.0", "pytest-asyncio", "pytest-cov", "httpx", "anthropic"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-persona-server"

--- a/test/unittests/test_compat_anthropic.py
+++ b/test/unittests/test_compat_anthropic.py
@@ -1,0 +1,141 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for persona server compatibility routers.
+
+All compat routers mount under a vendor-namespaced prefix to avoid conflicts:
+  /v1/...                  OpenAI (chat_router — original prefix)
+  /api/...                 Ollama (ollama_router — original prefix)
+  /anthropic/v1/...        Anthropic Claude
+  /gemini/v1beta/models/.. Google Gemini
+  /cohere/v1/...           Cohere
+  /tgi/...                 HuggingFace TGI
+  /bedrock/model/...       AWS Bedrock
+
+Uses dependency-override to replace the live Persona with a lightweight stub.
+"""
+import json
+from typing import Dict, Generator, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fake persona
+# ---------------------------------------------------------------------------
+
+class FakePersona:
+    name: str = "fake-persona"
+    config: dict = {}
+
+    def chat(self, messages: List[Dict], **kwargs) -> str:
+        return "hello from fake persona"
+
+    def stream(self, messages: List[Dict], **kwargs) -> Generator[str, None, None]:
+        for word in ["hello", " ", "streaming"]:
+            yield word
+
+    class solvers:
+        loaded_modules: dict = {}
+
+
+FAKE_PERSONA = FakePersona()
+
+
+def _override_persona():
+    return FAKE_PERSONA
+
+
+# ---------------------------------------------------------------------------
+# App builder
+# ---------------------------------------------------------------------------
+
+def _make_app() -> FastAPI:
+    from ovos_persona_server.persona import get_default_persona
+    from ovos_persona_server.chat import chat_router
+    from ovos_persona_server.ollama import ollama_router
+    from ovos_persona_server.anthropic import anthropic_router
+    from ovos_persona_server.deprecated_routers import (
+        add_deprecation_middleware,
+        register_deprecated_routes,
+    )
+
+    app = FastAPI()
+    app.include_router(chat_router)         # /openai/v1/...
+    app.include_router(ollama_router)       # /ollama/api/...
+    app.include_router(anthropic_router)    # /anthropic/v1/...
+    register_deprecated_routes(app)         # /v1/... and /api/... (deprecated)
+    add_deprecation_middleware(app)
+    app.dependency_overrides[get_default_persona] = _override_persona
+    return app
+
+
+@pytest.fixture(scope="module")
+def client():
+    app = _make_app()
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI chat  (canonical prefix: /openai/v1)
+# ---------------------------------------------------------------------------
+
+# Anthropic  (prefix: /anthropic/v1)
+# ---------------------------------------------------------------------------
+
+class TestAnthropicRouter:
+    def test_create_message_non_stream(self, client):
+        resp = client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "claude-3-opus-20240229",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+            },
+            headers={"x-api-key": "fake-key"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["type"] == "message"
+        assert body["content"][0]["text"] == "hello from fake persona"
+
+    def test_create_message_stream(self, client):
+        resp = client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "claude-3-opus-20240229",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        events = [l for l in resp.text.splitlines() if l.startswith("event:")]
+        event_types = [e.split(": ", 1)[1] for e in events]
+        assert "message_start" in event_types
+        assert "message_stop" in event_types
+
+    def test_empty_messages_rejected(self, client):
+        resp = client.post(
+            "/anthropic/v1/messages",
+            json={"model": "claude-3-opus-20240229", "messages": [], "max_tokens": 100},
+        )
+        assert resp.status_code == 422
+
+    def test_zero_max_tokens_rejected(self, client):
+        resp = client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "claude-3-opus-20240229",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 0,
+            },
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Gemini  (prefix: /gemini/v1beta/models)
+# ---------------------------------------------------------------------------
+

--- a/tests/e2e/test_e2e_anthropic.py
+++ b/tests/e2e/test_e2e_anthropic.py
@@ -1,0 +1,144 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests for the Anthropic-compatible API surface.
+
+These exercise the real deployment path a user hits in production: the
+official ``anthropic`` Python SDK pointed at a live ovos-persona-server
+instance. A minimal FastAPI app is built from ``anthropic_router`` with a
+mocked Persona, served by uvicorn on a free port in a background thread, and
+driven by ``anthropic.Anthropic(base_url=...)`` exactly as a real client would.
+
+Run in isolation::
+
+    pytest tests/e2e/test_e2e_anthropic.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI
+from unittest.mock import MagicMock
+
+anthropic = pytest.importorskip("anthropic", reason="anthropic SDK not installed")
+
+_CHAT_REPLY = "The capital of France is Paris."
+_STREAM_CHUNKS = ["The ", "capital ", "of ", "France ", "is ", "Paris."]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_app() -> FastAPI:
+    from ovos_persona_server.anthropic import anthropic_router
+    from ovos_persona_server.persona import get_default_persona
+
+    persona = MagicMock()
+    persona.name = "test-persona"
+    persona.chat.return_value = _CHAT_REPLY
+    # fresh iterator per call so multiple streaming requests work
+    persona.stream.side_effect = lambda messages: iter(_STREAM_CHUNKS)
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+
+    @app.get("/health")
+    def _health() -> dict:
+        return {"ok": True}
+
+    app.dependency_overrides[get_default_persona] = lambda: persona
+    return app
+
+
+@pytest.fixture(scope="module")
+def client() -> anthropic.Anthropic:
+    port = _free_port()
+    config = uvicorn.Config(_build_app(), host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.time() + 10
+    base = f"http://127.0.0.1:{port}"
+    while time.time() < deadline:
+        try:
+            if httpx.get(f"{base}/health", timeout=1).status_code == 200:
+                break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        server.should_exit = True
+        raise RuntimeError("server did not start in time")
+
+    # the SDK appends /v1/messages; our router prefix is /anthropic/v1
+    yield anthropic.Anthropic(base_url=f"{base}/anthropic", api_key="test-key")
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+def test_messages_create_roundtrip(client):
+    msg = client.messages.create(
+        model="claude-3-opus-20240229",
+        max_tokens=128,
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+    )
+    assert msg.role == "assistant"
+    assert msg.content[0].type == "text"
+    assert msg.content[0].text == _CHAT_REPLY
+    assert msg.model == "claude-3-opus-20240229"
+    assert msg.usage.output_tokens > 0
+
+
+def test_messages_with_system_prompt(client):
+    msg = client.messages.create(
+        model="claude-3-haiku-20240307",
+        max_tokens=64,
+        system="You are a geography teacher.",
+        messages=[{"role": "user", "content": "capital of France?"}],
+    )
+    assert msg.content[0].text == _CHAT_REPLY
+
+
+def test_messages_multi_turn(client):
+    msg = client.messages.create(
+        model="claude-3-opus-20240229",
+        max_tokens=64,
+        messages=[
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+            {"role": "user", "content": "capital of France?"},
+        ],
+    )
+    assert msg.content[0].text == _CHAT_REPLY
+
+
+def test_messages_streaming(client):
+    chunks = []
+    with client.messages.stream(
+        model="claude-3-opus-20240229",
+        max_tokens=128,
+        messages=[{"role": "user", "content": "capital of France?"}],
+    ) as stream:
+        for text in stream.text_stream:
+            chunks.append(text)
+        final = stream.get_final_message()
+    assert "".join(chunks) == "".join(_STREAM_CHUNKS)
+    assert final.role == "assistant"

--- a/tests/test_a2a_server.py
+++ b/tests/test_a2a_server.py
@@ -388,7 +388,7 @@ class TestOVOSPersonaAgentExecutor:
         executor, mod, classes, mock_persona = self._make_executor(stubs)
         ctx = self._make_context(classes, "Tell me a story.")
         eq = self._make_event_queue(classes)
-        asyncio.get_event_loop().run_until_complete(executor.execute(ctx, eq))
+        asyncio.run(executor.execute(ctx, eq))
         mock_persona.stream.assert_called_once()
         call_args = mock_persona.stream.call_args[0][0]
         assert call_args[0]["role"] == "user"
@@ -399,7 +399,7 @@ class TestOVOSPersonaAgentExecutor:
         executor, mod, classes, _ = self._make_executor(stubs, stream_yields=["hello", "world"])
         ctx = self._make_context(classes)
         eq = self._make_event_queue(classes)
-        asyncio.get_event_loop().run_until_complete(executor.execute(ctx, eq))
+        asyncio.run(executor.execute(ctx, eq))
         # Should have 2 artifact events + 1 status event
         assert eq.enqueue_event.call_count == 3
 
@@ -408,7 +408,7 @@ class TestOVOSPersonaAgentExecutor:
         executor, mod, classes, _ = self._make_executor(stubs, stream_yields=["hi"])
         ctx = self._make_context(classes)
         eq = self._make_event_queue(classes)
-        asyncio.get_event_loop().run_until_complete(executor.execute(ctx, eq))
+        asyncio.run(executor.execute(ctx, eq))
         # Last enqueued event should be TaskStatusUpdateEvent with completed state
         last_call_args = eq.enqueue_event.call_args_list[-1][0][0]
         assert last_call_args.status.state == "completed"
@@ -419,7 +419,7 @@ class TestOVOSPersonaAgentExecutor:
         executor, mod, classes, _ = self._make_executor(stubs, stream_yields=["", "hello", ""])
         ctx = self._make_context(classes)
         eq = self._make_event_queue(classes)
-        asyncio.get_event_loop().run_until_complete(executor.execute(ctx, eq))
+        asyncio.run(executor.execute(ctx, eq))
         # Only 1 artifact event (non-empty chunk) + 1 status event
         assert eq.enqueue_event.call_count == 2
 
@@ -428,7 +428,7 @@ class TestOVOSPersonaAgentExecutor:
         executor, mod, classes, _ = self._make_executor(stubs)
         ctx = self._make_context(classes)
         eq = self._make_event_queue(classes)
-        asyncio.get_event_loop().run_until_complete(executor.cancel(ctx, eq))
+        asyncio.run(executor.cancel(ctx, eq))
         eq.enqueue_event.assert_called_once()
         event = eq.enqueue_event.call_args[0][0]
         assert event.status.state == "canceled"

--- a/tests/test_compat_anthropic.py
+++ b/tests/test_compat_anthropic.py
@@ -1,0 +1,317 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the Anthropic-compatible API endpoints.
+
+Covers:
+- Schema validation (missing/bad fields → 422)
+- Non-streaming single-turn and multi-turn conversations
+- System message handling (prepended to messages)
+- Streaming variant (SSE events)
+- Unknown model name tolerance
+- Response-shape fidelity against the real Anthropic API format
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_app(chat_returns="hello", stream_yields=None):
+    """Build a test app with a mocked persona injected."""
+    from ovos_persona_server.anthropic import anthropic_router
+    from ovos_persona_server.persona import get_default_persona
+
+    if stream_yields is None:
+        stream_yields = ["hi ", "there"]
+
+    mock_persona = MagicMock()
+    mock_persona.chat.return_value = chat_returns
+    mock_persona.stream.return_value = iter(stream_yields)
+    mock_persona.name = "test-persona"
+
+    app = FastAPI()
+    app.include_router(anthropic_router)
+    app.dependency_overrides[get_default_persona] = lambda: mock_persona
+    return app, mock_persona
+
+
+_VALID_BODY = {
+    "model": "claude-3-opus",
+    "messages": [{"role": "user", "content": "Hello"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+class TestAnthropicSchemaValidation:
+    def setup_method(self):
+        self.app, _ = _make_app()
+        self.client = TestClient(self.app, raise_server_exceptions=False)
+
+    def test_missing_model_422(self):
+        resp = self.client.post("/anthropic/v1/messages", json={
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert resp.status_code == 422
+
+    def test_missing_messages_422(self):
+        resp = self.client.post("/anthropic/v1/messages", json={"model": "claude-3"})
+        assert resp.status_code == 422
+
+    def test_empty_messages_list_422(self):
+        resp = self.client.post("/anthropic/v1/messages", json={
+            "model": "claude-3", "messages": [],
+        })
+        assert resp.status_code == 422
+
+    def test_invalid_role_422(self):
+        resp = self.client.post("/anthropic/v1/messages", json={
+            "model": "claude-3",
+            "messages": [{"role": "badactor", "content": "hi"}],
+        })
+        assert resp.status_code == 422
+
+    def test_zero_max_tokens_422(self):
+        resp = self.client.post("/anthropic/v1/messages", json={
+            "model": "claude-3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 0,
+        })
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming responses
+# ---------------------------------------------------------------------------
+
+class TestAnthropicNonStreaming:
+    def setup_method(self):
+        self.app, self.mock_persona = _make_app(chat_returns="I am Claude.")
+        self.client = TestClient(self.app)
+
+    def test_200_ok(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.status_code == 200
+
+    def test_response_type_field(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.json()["type"] == "message"
+
+    def test_response_role_is_assistant(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.json()["role"] == "assistant"
+
+    def test_response_has_content_list(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        body = resp.json()
+        assert isinstance(body["content"], list)
+        assert len(body["content"]) > 0
+        assert body["content"][0]["type"] == "text"
+        assert body["content"][0]["text"] == "I am Claude."
+
+    def test_response_has_id(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.json()["id"].startswith("msg_")
+
+    def test_response_model_echoed(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.json()["model"] == "claude-3-opus"
+
+    def test_response_stop_reason(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.json()["stop_reason"] == "end_turn"
+
+    def test_response_usage_keys(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        usage = resp.json()["usage"]
+        assert "input_tokens" in usage
+        assert "output_tokens" in usage
+
+    def test_exact_envelope_keys(self):
+        """Response must contain all required Anthropic envelope keys."""
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        body = resp.json()
+        required_keys = {"id", "type", "role", "content", "model", "stop_reason", "usage"}
+        assert required_keys.issubset(body.keys())
+
+    def test_unknown_model_tolerated(self):
+        """Unknown model names must not cause errors — they are passed through."""
+        resp = self.client.post("/anthropic/v1/messages", json={
+            "model": "claude-999-unknown",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "claude-999-unknown"
+
+    def test_unknown_extra_params_tolerated(self):
+        """Extra unknown fields in the request body must not cause errors."""
+        resp = self.client.post("/anthropic/v1/messages", json={
+            **_VALID_BODY,
+            "future_param": "ignored",
+            "top_k": 40,
+        })
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Multi-message conversations
+# ---------------------------------------------------------------------------
+
+class TestAnthropicMultiTurn:
+    def setup_method(self):
+        self.app, self.mock_persona = _make_app(chat_returns="Sure!")
+        self.client = TestClient(self.app)
+
+    def test_multi_turn_passes_all_messages_to_persona(self):
+        body = {
+            "model": "claude-3",
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "4"},
+                {"role": "user", "content": "And 3+3?"},
+            ],
+        }
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert resp.status_code == 200
+        call_args = self.mock_persona.chat.call_args[0][0]
+        assert len(call_args) == 3
+        assert "3+3" in call_args[-1]["content"]
+
+    def test_content_block_list_flattened(self):
+        """content as a list of AnthropicContentBlocks must be joined to string."""
+        body = {
+            "model": "claude-3",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Hello"}, {"type": "text", "text": "World"}]},
+            ],
+        }
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert resp.status_code == 200
+        call_args = self.mock_persona.chat.call_args[0][0]
+        assert "Hello" in call_args[0]["content"] and "World" in call_args[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# System message handling
+# ---------------------------------------------------------------------------
+
+class TestAnthropicSystemMessage:
+    def setup_method(self):
+        self.app, self.mock_persona = _make_app(chat_returns="Yes!")
+        self.client = TestClient(self.app)
+
+    def test_system_field_prepended(self):
+        body = {
+            "model": "claude-3",
+            "messages": [{"role": "user", "content": "Are you there?"}],
+            "system": "You are a helpful assistant.",
+        }
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert resp.status_code == 200
+        messages = self.mock_persona.chat.call_args[0][0]
+        assert messages[0]["role"] == "system"
+        assert "helpful assistant" in messages[0]["content"]
+        assert messages[1]["role"] == "user"
+
+    def test_no_system_field_no_system_message(self):
+        resp = self.client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        messages = self.mock_persona.chat.call_args[0][0]
+        assert messages[0]["role"] != "system"
+
+
+# ---------------------------------------------------------------------------
+# Streaming variant
+# ---------------------------------------------------------------------------
+
+class TestAnthropicStreaming:
+    def setup_method(self):
+        self.app, self.mock_persona = _make_app(stream_yields=["Hello ", "World"])
+        self.client = TestClient(self.app)
+
+    def test_streaming_200(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert resp.status_code == 200
+
+    def test_streaming_content_type(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert "text/event-stream" in resp.headers.get("content-type", "")
+
+    def test_streaming_has_message_start(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert "message_start" in resp.text
+
+    def test_streaming_has_content_block_delta(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert "content_block_delta" in resp.text
+
+    def test_streaming_has_message_stop(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert "message_stop" in resp.text
+
+    def test_streaming_delta_contains_text(self):
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert "Hello" in resp.text or "World" in resp.text
+
+    def test_streaming_error_path(self):
+        """When persona.stream raises, error event is emitted."""
+        self.mock_persona.stream.side_effect = RuntimeError("stream broke")
+        body = {**_VALID_BODY, "stream": True}
+        resp = self.client.post("/anthropic/v1/messages", json=body)
+        assert resp.status_code == 200
+        assert "error" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# API key header
+# ---------------------------------------------------------------------------
+
+class TestAnthropicAPIKey:
+    def setup_method(self):
+        self.app, _ = _make_app()
+        self.client = TestClient(self.app)
+
+    def test_x_api_key_accepted_and_ignored(self):
+        resp = self.client.post(
+            "/anthropic/v1/messages",
+            json=_VALID_BODY,
+            headers={"x-api-key": "sk-ant-fake-key"},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+class TestAnthropicErrorPaths:
+    def test_persona_chat_exception_returns_500(self):
+        app, mock_persona = _make_app()
+        mock_persona.chat.side_effect = RuntimeError("backend down")
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/anthropic/v1/messages", json=_VALID_BODY)
+        assert resp.status_code == 500


### PR DESCRIPTION
Anthropic Claude-compatible endpoints (/anthropic/v1/messages). Non-streaming and SSE streaming. x-api-key header accepted and ignored.

Base: #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Tests
```
29 passed
```