### PR TITLE
fix(deps): pin released ovos-chromadb-embeddings-plugin>=0.3.0a4; drop last git-ref

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,10 +6,10 @@ name: End-to-End Tests
 #   - text embeddings: ovos-gguf-embeddings-plugin (downloads all-MiniLM-L6-v2)
 #   - vector DBs:       ovos-chromadb-embeddings-plugin + ovos-qdrant-embeddings-plugin
 #   - chat solver:      ovos-solver-openai-plugin (upstream LLM call mocked in-test)
-#   - RAG client:       ovos-openai-plugin OpenAIRAGSolver
+#   - RAG memory:       ovos-openai-plugin PersonaServerRAGMemory
 #
-# The companion RAG solver lives on the ovos-openai-plugin `rag` branch (PR #37),
-# pulled via pre_install_pip until it is released.
+# The whole stack is released on PyPI and pinned in the [e2e] extra, so this runs with
+# no pre_install_pip git-refs.
 on:
   push:
     branches: [dev]
@@ -23,11 +23,8 @@ jobs:
       # e2e is heavy (model download + native deps); a single modern Python is enough.
       python_versions: '["3.11"]'
       install_extras: "e2e"
-      # Pinned in pyproject (released): tool-call contract in ovos-plugin-manager>=2.7.0a1,
-      # memory-plugin config in ovos-persona>=0.9.0a6, PersonaServerRAGMemory in the [e2e]
-      # extra via ovos-openai-plugin>=2.0.8a1. Still unreleased:
-      #  - ovos-chromadb-embeddings-plugin only has a 0.0.0 placeholder on PyPI; the
-      #    collection-aware API needed here lives on `dev`
-      pre_install_pip: "git+https://github.com/OpenVoiceOS/ovos-chromadb-embeddings-plugin@dev"
+      # The full real stack is now released and pinned in the [e2e] extra
+      # (ovos-plugin-manager>=2.7.0a1, ovos-persona>=0.9.0a6, ovos-openai-plugin>=2.0.8a1,
+      # ovos-chromadb-embeddings-plugin>=0.3.0a4) — no pre_install_pip git-refs needed.
       test_path: "tests/e2e"
       pr_comment: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ e2e = [
     # real embedding + vector-store + RAG plugin stack
     "ovos-openai-plugin>=2.0.8a1",  # PersonaServerRAGMemory memory plugin
     "ovos-gguf-plugin",
-    "ovos-chromadb-embeddings-plugin",
+    "ovos-chromadb-embeddings-plugin>=0.3.0a4",  # collection-aware EmbeddingsDB API
     "ovos-qdrant-embeddings-plugin",
     "ovos-document-chunkers",
     "ovos-flashrank-reranker-plugin",


### PR DESCRIPTION
`ovos-chromadb-embeddings-plugin` 0.3.0a4 (collection-aware EmbeddingsDB API) is now published on PyPI, so:
- pin `ovos-chromadb-embeddings-plugin>=0.3.0a4` in the `[e2e]` extra, and
- remove the final `pre_install_pip` git-ref (`chromadb@dev`) from `e2e.yml`.

Also refreshes the stale `e2e.yml` header (it referenced the old `OpenAIRAGSolver` / PR #37 `rag` branch; the RAG path is now `PersonaServerRAGMemory`).

**The persona agent chain is now fully git-ref-free** — the entire e2e stack (opm 2.7.0a1, ovos-persona 0.9.0a6, ovos-openai-plugin 2.0.8a1, ovos-chromadb-embeddings-plugin 0.3.0a4) is released and pinned in pyproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined end-to-end testing setup by pinning dependencies and removing manual git-ref installations
  * Updated testing documentation to reflect full test stack availability via PyPI extras

<!-- end of auto-generated comment: release notes by coderabbit.ai -->